### PR TITLE
Configure empty labels for Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    labels: []
     reviewers:
       - "CodyCBakerPhD"
     assignees:


### PR DESCRIPTION
## Summary
Updated the Dependabot configuration to explicitly set an empty labels array for automated dependency update pull requests.

## Changes
- Added `labels: []` to the Dependabot configuration in `.github/dependabot.yml`

## Details
This change ensures that Dependabot pull requests will not automatically receive any labels when created. By explicitly setting an empty labels array, we maintain consistent pull request labeling behavior and prevent any default labels from being applied to dependency updates.

https://claude.ai/code/session_01Sp7NvinkoaChwk47eTxFmp