### PR TITLE
Support configurable branch tracking for input subdatasets

### DIFF
--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -42,8 +42,15 @@ BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
 # register it as an input subdataset. It is cloned into the derivatives dataset and pinned
 # in the provenance of every run. Leave it empty if this cache has no upstream input
 # dataset; the subdataset handling below is then skipped.
+#
+# INPUT_SUBDATASET_BRANCH selects which branch of the input dataset to track. dandi-cache
+# datasets publish their data on a dedicated branch (their default branch holds only code),
+# so this defaults to `derivatives`; set it to whatever branch the upstream cache publishes
+# to (e.g. `min`). It is recorded in `.gitmodules` so `submodule update --remote` follows
+# that branch on every run.
 INPUT_SUBDATASET_URL=""  # e.g. https://github.com/dandi-cache/<input-dataset-name>.git
 INPUT_SUBDATASET_PATH="sourcedata/<input-dataset-name>"
+INPUT_SUBDATASET_BRANCH="derivatives"
 
 DS="${RUNNER_TEMP:-/tmp}/derivatives-dataset"
 DISTDIR="${RUNNER_TEMP:-/tmp}/dist-publish"
@@ -71,6 +78,11 @@ else
   datalad create --no-annex "${DS}"
   if [ -n "${INPUT_SUBDATASET_URL}" ]; then
     datalad clone -d "${DS}" "${INPUT_SUBDATASET_URL}" "${DS}/${INPUT_SUBDATASET_PATH}"
+    # Track the input dataset's published-data branch (its default branch holds only code),
+    # and record that branch in `.gitmodules` so `submodule update --remote` follows it.
+    git -C "${DS}/${INPUT_SUBDATASET_PATH}" fetch origin "${INPUT_SUBDATASET_BRANCH}"
+    git -C "${DS}/${INPUT_SUBDATASET_PATH}" checkout -B "${INPUT_SUBDATASET_BRANCH}" "origin/${INPUT_SUBDATASET_BRANCH}"
+    git -C "${DS}" config -f .gitmodules "submodule.${INPUT_SUBDATASET_PATH}.branch" "${INPUT_SUBDATASET_BRANCH}"
   fi
   datalad save -d "${DS}" -m "Initialize derivatives dataset"
 fi


### PR DESCRIPTION
## Summary
This change adds support for tracking a configurable branch of input subdatasets, enabling proper handling of datasets that publish data on a dedicated branch separate from their default branch.

## Key Changes
- Added `INPUT_SUBDATASET_BRANCH` configuration variable (defaults to `"derivatives"`) to specify which branch of the input dataset to track
- Updated subdataset initialization to explicitly fetch and checkout the configured branch
- Configured git submodule to track the specified branch via `.gitmodules`, ensuring `submodule update --remote` follows the correct branch on subsequent runs
- Added documentation explaining the rationale (e.g., dandi-cache datasets publish data on a dedicated branch while keeping code on the default branch)

## Implementation Details
When cloning an input subdataset, the pipeline now:
1. Fetches the specified branch from the remote
2. Creates/updates a local branch tracking the remote branch
3. Records the branch preference in `.gitmodules` for future updates

This ensures that the pipeline consistently tracks the published data branch rather than the default branch, which may contain only code or metadata.

https://claude.ai/code/session_011SJMx56qU9m7RGn8RSnKhx