### PR TITLE
Add OCI image labels and source repository tracking to Docker build

### DIFF
--- a/.github/workflows/build_and_upload_docker_image.yml
+++ b/.github/workflows/build_and_upload_docker_image.yml
@@ -53,6 +53,8 @@ jobs:
           tags: |
             ghcr.io/dandi-cache/<cache-name>:latest
             ghcr.io/dandi-cache/<cache-name>:${{ github.sha }}
+          build-args: |
+            SOURCE_REPOSITORY_URL=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build_and_upload_docker_image.yml
+++ b/.github/workflows/build_and_upload_docker_image.yml
@@ -53,8 +53,6 @@ jobs:
           tags: |
             ghcr.io/dandi-cache/<cache-name>:latest
             ghcr.io/dandi-cache/<cache-name>:${{ github.sha }}
-          build-args: |
-            SOURCE_REPOSITORY_URL=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,24 @@ If you plan on using this cache regularly, clone the `dist` branch of this repos
 git clone --branch dist https://github.com/dandi-cache/<cache-name>.git
 ```
 
+Or, if you prefer [DataLad](https://www.datalad.org/) (options after the URL are passed through to `git clone`):
+
+```bash
+datalad clone https://github.com/dandi-cache/<cache-name>.git --branch dist
+```
+
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
 
 For example, through `crontab -e`, add:
 
 ```bash
 0 0 * * * git -C /path/to/<cache-name> pull
+```
+
+Or, with DataLad:
+
+```bash
+0 0 * * * datalad update -d /path/to/<cache-name> --how merge
 ```
 
 This will minimize data overhead by only loading the most recent changes.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone --branch dist https://github.com/dandi-cache/<cache-name>.git
 Or, if you prefer [DataLad](https://www.datalad.org/) (options after the URL are passed through to `git clone`):
 
 ```bash
-datalad clone https://github.com/dandi-cache/<cache-name>.git --branch dist
+datalad clone https://github.com/dandi-cache/<cache-name>.git --branch derivatives
 ```
 
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
@@ -56,12 +56,6 @@ For example, through `crontab -e`, add:
 
 ```bash
 0 0 * * * git -C /path/to/<cache-name> pull
-```
-
-Or, with DataLad:
-
-```bash
-0 0 * * * datalad update -d /path/to/<cache-name> --how merge
 ```
 
 This will minimize data overhead by only loading the most recent changes.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you plan on using this cache regularly, clone the `dist` branch of this repos
 git clone --branch dist https://github.com/dandi-cache/<cache-name>.git
 ```
 
-Or, if you prefer [DataLad](https://www.datalad.org/) (options after the URL are passed through to `git clone`):
+Or, if you prefer [DataLad](https://www.datalad.org/):
 
 ```bash
 datalad clone https://github.com/dandi-cache/<cache-name>.git --branch derivatives

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -12,11 +12,9 @@
 # it provides Python and a recent git-annex-standalone, which DataLad requires for the annex-backed dataset and its provenance.
 FROM neurodebian:trixie
 
-# GHCR associates a pushed image with its source repository through the org.opencontainers.image.source label.
-# The CI workflow passes the actual repository URL as a build argument, so caches instantiated from this template are linked automatically.
-ARG SOURCE_REPOSITORY_URL="https://github.com/dandi-cache/cache-template"
-LABEL org.opencontainers.image.source="${SOURCE_REPOSITORY_URL}"
-LABEL org.opencontainers.image.description="Pinned, reproducible runtime environment for this DANDI cache pipeline."
+# The source label associates the image on the GitHub Container Registry with this repository.
+LABEL org.opencontainers.image.source="https://github.com/dandi-cache/<cache-name>"
+LABEL org.opencontainers.image.description="The pinned runtime environment for the DANDI Cache <cache-name> update pipeline."
 
 # git-annex (for DataLad / annex provenance), Python, and the basics for cloning and TLS.
 RUN apt-get update \

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -12,6 +12,12 @@
 # it provides Python and a recent git-annex-standalone, which DataLad requires for the annex-backed dataset and its provenance.
 FROM neurodebian:trixie
 
+# GHCR associates a pushed image with its source repository through the org.opencontainers.image.source label.
+# The CI workflow passes the actual repository URL as a build argument, so caches instantiated from this template are linked automatically.
+ARG SOURCE_REPOSITORY_URL="https://github.com/dandi-cache/cache-template"
+LABEL org.opencontainers.image.source="${SOURCE_REPOSITORY_URL}"
+LABEL org.opencontainers.image.description="Pinned, reproducible runtime environment for this DANDI cache pipeline."
+
 # git-annex (for DataLad / annex provenance), Python, and the basics for cloning and TLS.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
This PR adds OpenContainers (OCI) image metadata labels to the Docker image and configures the CI workflow to automatically link built images to their source repository on GHCR.

## Key Changes
- **Dockerfile**: Added OCI image labels to the neurodebian base image:
  - `org.opencontainers.image.source`: Links the image to its source repository
  - `org.opencontainers.image.description`: Provides a human-readable description of the image purpose
  - Added `SOURCE_REPOSITORY_URL` build argument (defaults to the cache-template repository)

- **CI Workflow**: Updated the Docker build step to pass the repository URL as a build argument:
  - Constructs the source repository URL from GitHub context variables (`github.server_url` and `github.repository`)
  - Enables automatic association of pushed images with their source repository on GHCR

## Implementation Details
The `SOURCE_REPOSITORY_URL` build argument uses a default value pointing to the cache-template repository, but the CI workflow overrides it with the actual repository URL at build time. This ensures that images built from this template in different repositories are correctly linked to their respective source repositories on GHCR, improving discoverability and traceability of container images.

https://claude.ai/code/session_01E9tcKaX2F5DCKMS7FQkga9