### PR TITLE
Serialize updates via a workflow-wide concurrency group and skip runs made redundant by queueing

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,35 +15,51 @@ on:
         type: number
         default: 2000
 
+# Serialize all runs of this workflow, across every ref: an in-progress update is never
+# cancelled, and a run triggered while one is executing waits in the queue. The Gate job
+# below then skips the queued run once it starts, because the update it would perform has
+# just been done; if the preceding run failed, the queued run proceeds as a fresh attempt.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 env:
   GITHUB_TOKEN: ${{ secrets._GITHUB_API_KEY }}
 
 jobs:
+  Gate:
+    permissions: {}
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Skip if an update already completed while this run was queued
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets._GITHUB_API_KEY }}
+        run: |
+          CREATED_AT=$(gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --json createdAt --jq '.createdAt')
+          LAST_SUCCESS_AT=$(gh run list --repo "${{ github.repository }}" --workflow "${{ github.workflow }}" --status success --limit 1 --json updatedAt --jq '.[0].updatedAt // empty')
+
+          # ISO 8601 UTC timestamps compare correctly as strings. A successful run that
+          # finished after this run was triggered means this run spent its life queued
+          # behind it and would only repeat the same update.
+          if [ -n "${LAST_SUCCESS_AT}" ] && [ "${LAST_SUCCESS_AT}" \> "${CREATED_AT}" ]; then
+            echo "An update succeeded at ${LAST_SUCCESS_AT}, after this run was triggered at ${CREATED_AT}; skipping the redundant run."
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Update:
+    needs: [ Gate ]
+    if: ${{ needs.Gate.outputs.should-run == 'true' }}
     permissions:
-      actions: write
       contents: read
       packages: read
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check for running workflows
-        env:
-          GH_TOKEN: ${{ secrets._GITHUB_API_KEY }}
-        run: |
-          RUNNING_COUNT=$(gh run list --repo "${{ github.repository }}" --workflow "${{ github.workflow }}" --status in_progress --json databaseId | jq '. | length')
-
-          if [ "$RUNNING_COUNT" -gt 1 ]; then
-            echo "Another run is already in progress. Cancelling this run..."
-            gh run cancel --repo "${{ github.repository }}" ${{ github.run_id }}
-            # Sleep to allow cancellation to propagate
-            sleep 60
-          fi
-
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -72,7 +88,7 @@ jobs:
 
   NotifyOnFailure:
     runs-on: ubuntu-latest
-    needs: [ Update ]
+    needs: [ Gate, Update ]
     if: ${{ always() && failure() }}
     permissions: {}
     steps:


### PR DESCRIPTION
## Summary
Ports the Update-workflow run-serialization redesign from dandi-cache/content-id-to-dandiset-paths#10 into the template. The desired semantics: a trigger arriving while an update is executing must never cancel it and never overlap it, and a run that waited in the queue behind an update that succeeded must not repeat the work — but must still proceed if the predecessor failed.

## Key Changes
- The concurrency group is now scoped to the workflow only (no ref), so cross-branch dispatches are serialized too — the gap the manual "Check for running workflows" step existed to cover. `cancel-in-progress: false` keeps an in-flight update safe from new triggers.
- A new `Gate` job replaces the manual self-cancel step: it skips the `Update` job when a run of this workflow **succeeded after this run was created**, which can only happen if that run was already executing at trigger time (i.e., this run spent its life queued behind it). A run that started immediately always proceeds; a queued run whose predecessor failed proceeds as a fresh attempt. ISO 8601 UTC timestamps are compared as strings.
- The `actions: write` permission and the `sleep 60` cancellation hack are no longer needed and are removed; a skipped run shows as neutral "skipped" rather than "cancelled".
- `NotifyOnFailure` now depends on both `Gate` and `Update`, so a Gate failure still sends mail.

## Verification
- `check-yaml` passes; the same design is live in content-id-to-dandiset-paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX)_