### PR TITLE
Write reproducible gzip output (mtime=0)

### DIFF
--- a/code/compress.py
+++ b/code/compress.py
@@ -5,9 +5,14 @@ import shutil
 
 
 def _compress(file_path: pathlib.Path, /) -> None:
-
     compressed_file_path = file_path.parent / f"{file_path.name}.gz"
-    with file_path.open(mode="rb") as source_stream, gzip.open(compressed_file_path, mode="wb") as target_stream:
+    # `mtime=0` keeps the gzip header timestamp-free, so unchanged input compresses to a
+    # byte-identical artifact run after run.
+    with (
+        file_path.open(mode="rb") as source_stream,
+        compressed_file_path.open(mode="wb") as raw_target_stream,
+        gzip.GzipFile(fileobj=raw_target_stream, mode="wb", mtime=0) as target_stream,
+    ):
         shutil.copyfileobj(fsrc=source_stream, fdst=target_stream)
 
 


### PR DESCRIPTION
## Summary
gzip embeds the current time in its header by default, so an unchanged cache compressed to a byte-different `.gz` on every run. Zeroing the header timestamp (`gzip.GzipFile(..., mtime=0)` instead of `gzip.open`) makes identical input produce a byte-identical artifact, keeping the published dist stable when nothing changed. Ported from dandi-cache/content-id-to-dandiset-paths#10.

## Verification
- Compressing the same input twice yields byte-identical output, and the roundtrip decompresses correctly
- `ruff` and `black` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX)_