### PR TITLE
Document network-input lessons in the update.py skeleton

### DIFF
--- a/code/update.py
+++ b/code/update.py
@@ -16,6 +16,23 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     #      case). If you fetch inputs over the network, remember the processing container
     #      must have outbound network access at run time.
     #
+    # Lessons from caches that fetch from the public DANDI S3 bucket
+    # (see dandi-cache/content-id-to-dandiset-paths):
+    #   - Objects that appear in a bucket listing can still deny an anonymous GetObject:
+    #     embargoed Dandisets list their manifests publicly but return AccessDenied, and an
+    #     object can be deleted between listing and fetching (NoSuchKey). Catch
+    #     botocore.exceptions.ClientError, skip those two error codes with a log line, and
+    #     re-raise anything else — do not let an expected upstream state fail the whole run.
+    #   - When downloading with a ThreadPoolExecutor, size the client's connection pool to
+    #     the worker count (botocore's default pool of 10 makes surplus workers redo the
+    #     TCP/TLS handshake on every request) and use retries={"mode": "standard"}:
+    #     botocore.config.Config(signature_version=botocore.UNSIGNED,
+    #     max_pool_connections=max_workers, retries={"mode": "standard"}).
+    #   - Prefer JSON inputs over YAML wherever the source offers both (the DANDI archive
+    #     publishes assets.jsonld next to every assets.yaml): parsing large YAML in Python
+    #     is GIL-bound and orders of magnitude slower than json.loads, and threads do not
+    #     parallelize it — it can dominate the entire run time.
+    #
     # `limit` is an optional batch size for incremental, resumable runs: process at most
     # `limit` new items per invocation and skip those already recorded in the derivatives.
     # Remove it (and the `--limit` plumbing in update_pipeline.sh and update.yml) if this


### PR DESCRIPTION
## Summary
Adds hard-won advice to the `update.py` skeleton's TODO block for first-in-chain caches that fetch inputs directly from the public DANDI S3 bucket, earned while debugging and speeding up dandi-cache/content-id-to-dandiset-paths (#9, #10). Comment-only — no code or dependency changes.

## Key Changes
The TODO block now documents three pitfalls:
- **Listed ≠ readable**: embargoed Dandisets list their manifests publicly but deny anonymous `GetObject` (`AccessDenied`), and objects can vanish between listing and fetching (`NoSuchKey`) — skip those per object with a log line instead of letting an expected upstream state fail the whole run
- **Pool sizing**: with a `ThreadPoolExecutor`, size `max_pool_connections` to the worker count (botocore's default pool of 10 makes surplus workers redo the TCP/TLS handshake on every request) and use `retries={"mode": "standard"}`
- **JSON over YAML**: pure-Python YAML parsing is GIL-bound, orders of magnitude slower than `json.loads`, and threads don't parallelize it — it can dominate the entire run time; the DANDI archive publishes `assets.jsonld` next to every `assets.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX)_