### PR TITLE
Add Claude Code skills for cache setup and DANDI S3 inputs

### DIFF
--- a/.claude/skills/dandi-s3-network-inputs/SKILL.md
+++ b/.claude/skills/dandi-s3-network-inputs/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: dandi-s3-network-inputs
+description: Hard-won lessons for cache update logic that fetches inputs directly from the public DANDI S3 bucket (the first-in-chain / no-input-dataset mode). Use when implementing, debugging, or speeding up code in update.py that lists or downloads objects from the DANDI archive bucket — especially with boto3/botocore, a ThreadPoolExecutor, or manifest parsing.
+---
+
+# Fetching inputs from the public DANDI S3 bucket
+
+Lessons earned while debugging and speeding up
+[dandi-cache/content-id-to-dandiset-paths](https://github.com/dandi-cache/content-id-to-dandiset-paths)
+(its PRs #9 and #10). They apply to any first-in-chain cache whose `update.py` pulls its
+own inputs from the public DANDI S3 bucket at run time.
+
+## Listed does not mean readable
+
+Objects that appear in a bucket listing can still deny an anonymous `GetObject`:
+
+- Embargoed Dandisets list their manifests publicly but return `AccessDenied`.
+- An object can be deleted between listing and fetching, returning `NoSuchKey`.
+
+Catch `botocore.exceptions.ClientError`, skip those two error codes per object with a log
+line, and re-raise anything else. Do not let an expected upstream state fail the whole run.
+
+## Size the connection pool to the worker count
+
+When downloading with a `ThreadPoolExecutor`, botocore's default connection pool of 10
+makes surplus workers redo the TCP/TLS handshake on every request. Configure the client
+with a pool matched to the executor and standard retries:
+
+```python
+botocore.config.Config(
+    signature_version=botocore.UNSIGNED,
+    max_pool_connections=max_workers,
+    retries={"mode": "standard"},
+)
+```
+
+## Prefer JSON inputs over YAML
+
+Parsing large YAML in pure Python is GIL-bound, orders of magnitude slower than
+`json.loads`, and threads do not parallelize it — it can dominate the entire run time.
+Wherever the source offers both formats, take the JSON: the DANDI archive publishes
+`assets.jsonld` next to every `assets.yaml`.

--- a/.claude/skills/setup-cache/SKILL.md
+++ b/.claude/skills/setup-cache/SKILL.md
@@ -9,6 +9,11 @@ Work through all of these steps in a single setup PR. `<cache-name>` is the hyph
 repository name (e.g., `my-cache`); `<cache_name>` is the underscored form used for file
 and variable names (e.g., `my_cache`).
 
+Before starting, read the README's **How it works** section — it explains the
+`main` / `derivatives` / `dist` branch layout and the container-based provenance that
+the pipeline relies on. (It is part of the scaffolding removed in step 4, so it only
+exists before setup.)
+
 ## 1. Replace placeholders and resolve TODO markers
 
 - Replace every `<cache-name>` / `<cache_name>` occurrence across the repository
@@ -25,13 +30,18 @@ and variable names (e.g., `my_cache`).
 Select one of the three input modes in `code/update_pipeline.sh` (the
 `INPUT_SUBDATASET_URL` TODO) and `code/update.py`:
 
-1. **Upstream DataLad dataset** — set `INPUT_SUBDATASET_URL`; the dataset is pinned in
-   the provenance of every run.
-2. **Local `sourcedata` directory** — committed fixtures; leave `INPUT_SUBDATASET_URL`
-   empty.
-3. **First-in-chain / no input dataset** — `update.py` fetches its own inputs over the
-   network at run time; leave `INPUT_SUBDATASET_URL` empty and remember the processing
-   container needs outbound network access. If the inputs come from the public DANDI S3
+1. **Upstream DataLad dataset.** Set `INPUT_SUBDATASET_URL` to register an upstream
+   dataset as an input subdataset. It is cloned into the `derivatives` dataset and
+   pinned via `--input` in the provenance of every run, so each result records the
+   exact input commit it was computed from.
+2. **Local `sourcedata` directory.** Inputs live under the dataset's own `sourcedata/`
+   (e.g. committed fixtures). Leave `INPUT_SUBDATASET_URL` empty.
+3. **First-in-chain / no input dataset.** The cache fetches its own inputs over the
+   network at run time (e.g. it queries a remote API or archive). Leave
+   `INPUT_SUBDATASET_URL` empty: there is no input dataset to pin, so no `--input`
+   provenance is declared. Because the inputs are pulled at run time, the processing
+   container requires outbound network access — the runtime environment must allow the
+   container to reach the upstream source. If the inputs come from the public DANDI S3
    bucket, read the `dandi-s3-network-inputs` skill before writing that code.
 
 ## 3. Implement the cache logic
@@ -42,16 +52,20 @@ Select one of the three input modes in `code/update_pipeline.sh` (the
   (and its plumbing in `update_pipeline.sh` and `update.yml`) if the cache is recomputed
   in full on every run.
 - Add the processing dependencies to `envs/pyproject.toml`.
+- The container image is the authoritative runtime, but recreate the environment
+  locally with [uv](https://docs.astral.sh/uv/) to debug and verify:
+  `uv run --project envs python code/update.py`.
 
 ## 4. Remove the template scaffolding
 
 These pieces document the template itself, not the generated cache — delete them in this
 same setup PR:
 
-- The README **How it works** section (including its **Input modes** subsection, once the
-  chosen input mode is wired up).
-- The README **Repository setup** section (including the **Set up with Claude Code** and
-  **Local development** subsections).
+- The README **How it works** section — the generated cache's README should describe
+  only the cache itself and how to consume it.
+- The README **Repository setup** section (including its **With Claude Code** and
+  **Manually** subsections).
 - `.claude/skills/setup-cache/` — this skill has no purpose once setup is done.
 - `.claude/skills/dandi-s3-network-inputs/` — only if this cache does **not** fetch
-  inputs from the DANDI S3 bucket; keep it when input mode 3 uses that bucket.
+  inputs from the DANDI S3 bucket; keep it when input mode 3 uses that bucket. If
+  nothing remains under `.claude/`, remove the directory entirely.

--- a/.claude/skills/setup-cache/SKILL.md
+++ b/.claude/skills/setup-cache/SKILL.md
@@ -72,8 +72,8 @@ same setup PR:
 
 - The README **How it works** section — the generated cache's README should describe
   only the cache itself and how to consume it.
-- The README **Repository setup** section (including its **With Claude Code** and
-  **Manually** subsections).
+- The README **Repository setup** section (including its **With Claude Code**
+  subsection).
 - `.claude/skills/setup-cache/` — this skill has no purpose once setup is done.
 - `.claude/skills/dandi-s3-network-inputs/` — only if this cache does **not** fetch
   inputs from the DANDI S3 bucket; keep it when input mode 3 uses that bucket. If

--- a/.claude/skills/setup-cache/SKILL.md
+++ b/.claude/skills/setup-cache/SKILL.md
@@ -27,30 +27,39 @@ exists before setup.)
 
 ## 2. Choose the input mode
 
-Select one of the three input modes in `code/update_pipeline.sh` (the
-`INPUT_SUBDATASET_URL` TODO) and `code/update.py`:
+Select one of the three input modes; the `INPUT_SUBDATASET_URL` / `INPUT_SUBDATASET_PATH`
+/ `INPUT_SUBDATASET_BRANCH` variables in `code/update_pipeline.sh` (the input-mode TODO)
+drive the choice, and `code/update.py` reads accordingly:
 
 1. **Upstream DataLad dataset.** Set `INPUT_SUBDATASET_URL` to register an upstream
    dataset as an input subdataset. It is cloned into the `derivatives` dataset and
    pinned via `--input` in the provenance of every run, so each result records the
-   exact input commit it was computed from.
+   exact input commit it was computed from. `INPUT_SUBDATASET_BRANCH` selects which
+   branch of the input dataset to track: dandi-cache datasets publish their data on a
+   dedicated branch (their default branch holds only code), so it defaults to
+   `derivatives` — set it to whatever branch the upstream cache publishes to (e.g.
+   `min`). It is recorded in `.gitmodules` so `submodule update --remote` follows that
+   branch on every run.
 2. **Local `sourcedata` directory.** Inputs live under the dataset's own `sourcedata/`
-   (e.g. committed fixtures). Leave `INPUT_SUBDATASET_URL` empty.
+   (e.g. committed fixtures). Leave `INPUT_SUBDATASET_URL` empty; optionally declare the
+   relevant paths as `--input` in the `containers-run` call to pin them in provenance.
 3. **First-in-chain / no input dataset.** The cache fetches its own inputs over the
    network at run time (e.g. it queries a remote API or archive). Leave
    `INPUT_SUBDATASET_URL` empty: there is no input dataset to pin, so no `--input`
    provenance is declared. Because the inputs are pulled at run time, the processing
    container requires outbound network access — the runtime environment must allow the
-   container to reach the upstream source. If the inputs come from the public DANDI S3
-   bucket, read the `dandi-s3-network-inputs` skill before writing that code.
+   container to reach the upstream source, and the `--call-fmt` in `update_pipeline.sh`
+   must not isolate the container's network. If the inputs come from the public DANDI
+   S3 bucket, read the `dandi-s3-network-inputs` skill before writing that code.
 
 ## 3. Implement the cache logic
 
 - Implement `_run` in `code/update.py`: read the inputs, compute the cache, and write the
   result into `derivatives/<cache_name>.jsonl` as JSON Lines.
-- Decide whether to keep `--limit`: keep it for incremental, resumable runs; remove it
-  (and its plumbing in `update_pipeline.sh` and `update.yml`) if the cache is recomputed
-  in full on every run.
+- Decide whether to keep `--limit`. It is a batch size for incremental, resumable runs:
+  process at most `limit` new items per invocation and skip those already recorded in
+  the derivatives. Remove it (and its plumbing in `update_pipeline.sh` and `update.yml`)
+  if the cache is recomputed in full on every run.
 - Add the processing dependencies to `envs/pyproject.toml`.
 - The container image is the authoritative runtime, but recreate the environment
   locally with [uv](https://docs.astral.sh/uv/) to debug and verify:

--- a/.claude/skills/setup-cache/SKILL.md
+++ b/.claude/skills/setup-cache/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: setup-cache
+description: First-time setup of a new DANDI cache repository generated from dandi-cache/cache-template. Use when asked to set up, initialize, or specialize this cache from the template — replacing placeholders, choosing an input mode, implementing update.py, and removing the template scaffolding.
+---
+
+# Setting up a new DANDI cache from the template
+
+Work through all of these steps in a single setup PR. `<cache-name>` is the hyphenated
+repository name (e.g., `my-cache`); `<cache_name>` is the underscored form used for file
+and variable names (e.g., `my_cache`).
+
+## 1. Replace placeholders and resolve TODO markers
+
+- Replace every `<cache-name>` / `<cache_name>` occurrence across the repository
+  (README, `code/`, `containers/`, `.github/workflows/`).
+- Resolve every `TODO` marker: the update schedule (cron in
+  `.github/workflows/update.yml`), the input dataset, and the notification recipients.
+- Fill in the placeholder fields in `dataset_description.json` (`Name`, `Authors`;
+  `License` defaults to `CC-BY-4.0` — change it if this cache uses a different license).
+- Write a short description of what the cache contains and how it is derived at the top
+  of the README.
+
+## 2. Choose the input mode
+
+Select one of the three input modes in `code/update_pipeline.sh` (the
+`INPUT_SUBDATASET_URL` TODO) and `code/update.py`:
+
+1. **Upstream DataLad dataset** — set `INPUT_SUBDATASET_URL`; the dataset is pinned in
+   the provenance of every run.
+2. **Local `sourcedata` directory** — committed fixtures; leave `INPUT_SUBDATASET_URL`
+   empty.
+3. **First-in-chain / no input dataset** — `update.py` fetches its own inputs over the
+   network at run time; leave `INPUT_SUBDATASET_URL` empty and remember the processing
+   container needs outbound network access. If the inputs come from the public DANDI S3
+   bucket, read the `dandi-s3-network-inputs` skill before writing that code.
+
+## 3. Implement the cache logic
+
+- Implement `_run` in `code/update.py`: read the inputs, compute the cache, and write the
+  result into `derivatives/<cache_name>.jsonl` as JSON Lines.
+- Decide whether to keep `--limit`: keep it for incremental, resumable runs; remove it
+  (and its plumbing in `update_pipeline.sh` and `update.yml`) if the cache is recomputed
+  in full on every run.
+- Add the processing dependencies to `envs/pyproject.toml`.
+
+## 4. Remove the template scaffolding
+
+These pieces document the template itself, not the generated cache — delete them in this
+same setup PR:
+
+- The README **How it works** section (including its **Input modes** subsection, once the
+  chosen input mode is wired up).
+- The README **Repository setup** section (including the **Set up with Claude Code** and
+  **Local development** subsections).
+- `.claude/skills/setup-cache/` — this skill has no purpose once setup is done.
+- `.claude/skills/dandi-s3-network-inputs/` — only if this cache does **not** fetch
+  inputs from the DANDI S3 bucket; keep it when input mode 3 uses that bucket.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,17 @@ After generating a repository from this template:
 1. Replace every `<cache-name>` / `<cache_name>` placeholder and resolve the `TODO` markers (the update schedule, the cache logic, the input dataset, the notification recipients). Fill in the placeholder fields in [`dataset_description.json`](dataset_description.json) (`Name`, `Authors`; `License` defaults to `CC-BY-4.0` — change it if this cache uses a different license).
 2. Add this cache's processing dependencies to [`envs/pyproject.toml`](envs/pyproject.toml).
 3. Specify the [`code/update.py`](code/update.py) protocol.
-4. Remove the template scaffolding from the local README — these sections document the template itself, not the generated cache. Delete the **How it works** section (including its **Input modes** subsection, once you have chosen and wired up an input mode) and this **Repository setup** section (including the **Local development** subsection below).
+4. Remove the template scaffolding — these pieces document the template itself, not the generated cache. Delete the **How it works** section (including its **Input modes** subsection, once you have chosen and wired up an input mode), this **Repository setup** section (including the **Set up with Claude Code** and **Local development** subsections below), and the `.claude/skills/setup-cache` skill (plus `.claude/skills/dandi-s3-network-inputs` if this cache does not fetch inputs from the DANDI S3 bucket).
+
+
+
+### Set up with Claude Code
+
+This template ships [Claude Code](https://claude.com/claude-code) skills under [`.claude/skills/`](.claude/skills) that encode the steps above (`setup-cache`) and hard-won guidance for caches that fetch inputs from the public DANDI S3 bucket (`dandi-s3-network-inputs`). To use them, open a Claude Code session in the freshly generated repository and start from a prompt like:
+
+> Set up this new DANDI cache using the setup-cache skill. The cache should `<describe what this cache computes, where its inputs come from, and how often it should update>`. Open the result as a single setup PR.
+
+The skill removes this section, along with the rest of the template scaffolding, as part of that first setup PR.
 
 
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,3 @@ After generating a repository from this template, the full setup checklist lives
 Open a [Claude Code](https://claude.com/claude-code) session in the freshly generated repository and start from a prompt like:
 
 > Set up this new DANDI cache using the setup-cache skill. The cache should `<describe what this cache computes, where its inputs come from, and how often it should update>`. Open the result as a single setup PR.
-
-### Manually
-
-The skill files are plain Markdown — follow the checklist directly. A companion skill, [`dandi-s3-network-inputs`](.claude/skills/dandi-s3-network-inputs/SKILL.md), collects lessons for caches that fetch their inputs from the public DANDI S3 bucket.

--- a/README.md
+++ b/README.md
@@ -80,41 +80,16 @@ The repository is described as a [BIDS study dataset](https://bids-specification
 
 
 
-### Input modes
-
-A cache's inputs can come from one of three first-class sources. Select the one that fits in [`code/update_pipeline.sh`](code/update_pipeline.sh) (the `INPUT_SUBDATASET_URL` TODO) and [`code/update.py`](code/update.py):
-
-1. **Upstream DataLad dataset.** Set `INPUT_SUBDATASET_URL` to register an upstream dataset as an input subdataset. It is cloned into the `derivatives` dataset and pinned via `--input` in the provenance of every run, so each result records the exact input commit it was computed from.
-2. **Local `sourcedata` directory.** Inputs live under the dataset's own `sourcedata/` (e.g. committed fixtures). Leave `INPUT_SUBDATASET_URL` empty.
-3. **First-in-chain / no input dataset.** The cache fetches its own inputs over the network at run time (e.g. it queries a remote API or archive). Leave `INPUT_SUBDATASET_URL` empty: there is no input dataset to pin, so no `--input` provenance is declared. Because the inputs are pulled at run time, **the processing container requires outbound network access** — the runtime environment must allow the container to reach the upstream source.
-
-
-
 ## Repository setup
 
-After generating a repository from this template:
+After generating a repository from this template, the full setup checklist lives in [`.claude/skills/setup-cache/SKILL.md`](.claude/skills/setup-cache/SKILL.md): replacing the placeholders, choosing an input mode, implementing the cache logic, and removing the template scaffolding (this section and the **How it works** section above included).
 
-1. Replace every `<cache-name>` / `<cache_name>` placeholder and resolve the `TODO` markers (the update schedule, the cache logic, the input dataset, the notification recipients). Fill in the placeholder fields in [`dataset_description.json`](dataset_description.json) (`Name`, `Authors`; `License` defaults to `CC-BY-4.0` — change it if this cache uses a different license).
-2. Add this cache's processing dependencies to [`envs/pyproject.toml`](envs/pyproject.toml).
-3. Specify the [`code/update.py`](code/update.py) protocol.
-4. Remove the template scaffolding — these pieces document the template itself, not the generated cache. Delete the **How it works** section (including its **Input modes** subsection, once you have chosen and wired up an input mode), this **Repository setup** section (including the **Set up with Claude Code** and **Local development** subsections below), and the `.claude/skills/setup-cache` skill (plus `.claude/skills/dandi-s3-network-inputs` if this cache does not fetch inputs from the DANDI S3 bucket).
+### With Claude Code
 
-
-
-### Set up with Claude Code
-
-This template ships [Claude Code](https://claude.com/claude-code) skills under [`.claude/skills/`](.claude/skills) that encode the steps above (`setup-cache`) and hard-won guidance for caches that fetch inputs from the public DANDI S3 bucket (`dandi-s3-network-inputs`). To use them, open a Claude Code session in the freshly generated repository and start from a prompt like:
+Open a [Claude Code](https://claude.com/claude-code) session in the freshly generated repository and start from a prompt like:
 
 > Set up this new DANDI cache using the setup-cache skill. The cache should `<describe what this cache computes, where its inputs come from, and how often it should update>`. Open the result as a single setup PR.
 
-The skill removes this section, along with the rest of the template scaffolding, as part of that first setup PR.
+### Manually
 
-
-
-### Local development
-
-The container image is the authoritative runtime, but you can recreate the environment locally with [uv](https://docs.astral.sh/uv/) for debugging:
-
-```bash
-uv run --project envs python code/update.py
-```
+The skill files are plain Markdown — follow the checklist directly. A companion skill, [`dandi-s3-network-inputs`](.claude/skills/dandi-s3-network-inputs/SKILL.md), collects lessons for caches that fetch their inputs from the public DANDI S3 bucket.

--- a/code/update.py
+++ b/code/update.py
@@ -5,23 +5,15 @@ import pathlib
 
 def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     # TODO: implement the update logic for this cache.
-    # Read the input data, compute the cache, and write the result into
+    # Read the inputs, compute the cache, and write the result into
     # `base_directory / "derivatives"` as JSON Lines (one JSON value per line).
-    #
-    # Inputs can come from one of three places, matching the input modes in
-    # update_pipeline.sh:
-    #   1. an input subdataset under `base_directory / "sourcedata"` (pinned in provenance),
-    #   2. a local `sourcedata` directory committed in the dataset, or
-    #   3. fetched directly over the network here (the first-in-chain / no-input-dataset
-    #      case). If you fetch inputs over the network, remember the processing container
-    #      must have outbound network access at run time. For inputs pulled from the
-    #      public DANDI S3 bucket, see .claude/skills/dandi-s3-network-inputs/SKILL.md
-    #      for lessons on access errors, connection pooling, and manifest formats.
-    #
     # `limit` is an optional batch size for incremental, resumable runs: process at most
     # `limit` new items per invocation and skip those already recorded in the derivatives.
-    # Remove it (and the `--limit` plumbing in update_pipeline.sh and update.yml) if this
-    # cache is recomputed in full on every run.
+    #
+    # The setup checklist — input modes, whether to keep `--limit`, and lessons for
+    # fetching inputs from the public DANDI S3 bucket — lives in the plain-Markdown
+    # skills .claude/skills/setup-cache/SKILL.md and
+    # .claude/skills/dandi-s3-network-inputs/SKILL.md.
 
     records: list = []
 

--- a/code/update.py
+++ b/code/update.py
@@ -14,7 +14,9 @@ def _run(base_directory: pathlib.Path, limit: int | None) -> None:
     #   2. a local `sourcedata` directory committed in the dataset, or
     #   3. fetched directly over the network here (the first-in-chain / no-input-dataset
     #      case). If you fetch inputs over the network, remember the processing container
-    #      must have outbound network access at run time.
+    #      must have outbound network access at run time. For inputs pulled from the
+    #      public DANDI S3 bucket, see .claude/skills/dandi-s3-network-inputs/SKILL.md
+    #      for lessons on access errors, connection pooling, and manifest formats.
     #
     # `limit` is an optional batch size for incremental, resumable runs: process at most
     # `limit` new items per invocation and skip those already recorded in the derivatives.

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -38,28 +38,11 @@ GITHUB_SHA="${GITHUB_SHA:-unknown}"
 BOT_NAME="github-actions[bot]"
 BOT_EMAIL="github-actions[bot]@users.noreply.github.com"
 
-# TODO: pick this cache's input mode. There are three first-class cases:
-#
-#   1. Upstream DataLad dataset (input subdataset): set INPUT_SUBDATASET_URL to register an
-#      upstream dataset as an input subdataset. It is cloned into the derivatives dataset and
-#      pinned in the provenance of every run via `--input`, so each result records the exact
-#      input commit it was computed from. INPUT_SUBDATASET_BRANCH selects which branch of the
-#      input dataset to track: dandi-cache datasets publish their data on a dedicated branch
-#      (their default branch holds only code), so this defaults to `derivatives`; set it to
-#      whatever branch the upstream cache publishes to (e.g. `min`). It is recorded in
-#      `.gitmodules` so `submodule update --remote` follows that branch on every run.
-#   2. Local `sourcedata` directory: inputs live under the dataset's own `sourcedata/` (e.g.
-#      committed fixtures). Leave INPUT_SUBDATASET_URL empty; declare the relevant paths as
-#      `--input` below if you want them pinned in provenance.
-#   3. First-in-chain / no input dataset: this cache fetches its own inputs over the network
-#      at run time (e.g. queries a remote API or archive). Leave INPUT_SUBDATASET_URL empty.
-#      There is no input dataset to pin, so no `--input` provenance is declared. NOTE: the
-#      processing container therefore REQUIRES outbound network access at run time; the
-#      `--call-fmt` below must not isolate the network, and the runtime environment must
-#      allow the container to reach the upstream source.
-#
-# Leave INPUT_SUBDATASET_URL empty for cases 2 and 3; the subdataset handling below is then
-# skipped.
+# TODO: pick this cache's input mode — upstream DataLad dataset, local `sourcedata`
+# directory, or first-in-chain network fetch. The three modes, and how these variables
+# drive them, are documented in .claude/skills/setup-cache/SKILL.md (step 2). Leave
+# INPUT_SUBDATASET_URL empty for the two non-subdataset modes; the subdataset handling
+# below is then skipped.
 INPUT_SUBDATASET_URL=""  # e.g. https://github.com/dandi-cache/<input-dataset-name>.git
 INPUT_SUBDATASET_PATH="sourcedata/<input-dataset-name>"
 INPUT_SUBDATASET_BRANCH="derivatives"

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -3,7 +3,7 @@
 # The container is the project's pinned, reproducible runtime environment and the official way to run the pipeline.
 # The loose dependencies declared in envs/pyproject.toml are resolved fresh at build time, and the resulting image (by digest) is the lock.
 # As such, there is no lockfile in the repository to hold in sync.
-# uv is intentionally not used inside the image; it stays an outside-the-container convenience for running locally while debugging (see the README).
+# uv is intentionally not used inside the image; it stays an outside-the-container convenience for running locally while debugging (`uv run --project envs python code/update.py`).
 #
 # The image holds only the environment, not the code.
 # The code is supplied at run time (checked out or mounted), so a single image serves any revision of the code.


### PR DESCRIPTION
## Summary
Restructures the template's setup guidance into Claude Code skills under `.claude/skills/`, making them the single source of truth for first-time setup. Supersedes #27: the network-input lessons proposed there as `update.py` comments become a skill instead of per-repo comment blocks that would drift.

## Key Changes
- **`.claude/skills/dandi-s3-network-inputs/SKILL.md`** — the hard-won lessons from dandi-cache/content-id-to-dandiset-paths (listed ≠ readable / `AccessDenied` + `NoSuchKey` handling, `max_pool_connections` sized to the thread pool, JSON over YAML), triggered when writing or debugging code that fetches from the public DANDI S3 bucket. `update.py` keeps a two-line pointer for readers not using Claude Code.
- **`.claude/skills/setup-cache/SKILL.md`** — the full first-setup checklist (placeholders, input-mode choice with complete mode descriptions, `update.py` implementation, uv-based local verification, scaffolding removal). Its final step deletes the README scaffolding, itself, and the network-inputs skill when inapplicable.
- **README deduplication** — the **Input modes**, setup-checklist, and **Local development** content moved wholly into the skill; the README's **Repository setup** section shrinks to a default Claude Code prompt invoking `setup-cache` plus a pointer for manual setup. The Dockerfile's uv comment now inlines the debug command instead of referencing the removed README section.

## Notes
- If this merges, #27 should be closed rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U5uo31kavEK2JtgzQ1rLM