### PR TITLE
Improve dataset status check to filter clean paths

### DIFF
--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -135,7 +135,10 @@ datalad save -m "Pin runtime container image to ${DIGEST}" .datalad
 # Fail fast if the dataset is not clean before the recorded run. `containers-run` requires a
 # clean tree to detect the command's changes and otherwise aborts with a generic "clean
 # dataset required" error; surfacing the offending paths here is far easier to diagnose.
-DATASET_STATUS=$(datalad status)
+# The JSON renderer is required: the default renderer prints "nothing to save, working tree
+# clean" on a clean dataset, and the JSON one also emits records for clean paths, so filter
+# to the non-clean states.
+DATASET_STATUS=$(datalad -f json status | jq -r 'select(.state != "clean") | "\(.state): \(.path)"')
 if [ -n "${DATASET_STATUS}" ]; then
   echo "ERROR: derivatives dataset is not clean before containers-run." >&2
   echo "Offending paths:" >&2


### PR DESCRIPTION
## Summary
Updated the dataset status check in the update pipeline to use JSON output and filter for only non-clean states, making error diagnostics clearer and more reliable.

## Key Changes
- Modified `datalad status` command to use JSON format (`-f json`) for structured output
- Added `jq` filter to select only non-clean paths (`select(.state != "clean")`)
- Formatted output to show state and path for easier diagnosis of offending files

## Implementation Details
The previous implementation relied on the default text renderer which prints "nothing to save, working tree clean" on a clean dataset. This message could be ambiguous when diagnosing issues. The new approach:
- Uses JSON output to get structured data about dataset state
- Filters to only include paths with non-clean states
- Formats the output as `state: path` for clear error reporting
- Maintains the same fail-fast behavior while improving diagnostic clarity

https://claude.ai/code/session_011ejRueUoKEjkdZcifuKvWS